### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 #DocDownloader - Download Docs from ReadTheDocs
 
-[![License](https://pypip.in/license/DocDownloader/badge.svg)](https://pypi.python.org/pypi/DocDownloader/)
-[![Development Status](https://pypip.in/status/DocDownloader/badge.svg)](https://pypi.python.org/pypi/DocDownloader/)
+[![License](https://img.shields.io/pypi/l/DocDownloader.svg)](https://pypi.python.org/pypi/DocDownloader/)
+[![Development Status](https://img.shields.io/pypi/status/DocDownloader.svg)](https://pypi.python.org/pypi/DocDownloader/)
 
 DocDownloader is a python 2/3 module/utility to download Documenation hosted on ReadTheDocs in HTML, PDF and EPUB Formats
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20docdownloader))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `docdownloader`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.